### PR TITLE
Refactor AWS session creation with profile support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project Overview
+
+ECstats is a Python-based tool for extracting AWS ElastiCache (Redis/Valkey) database metrics via CloudWatch. It's a single-file application that generates Excel reports containing performance metrics and instance information.
+
+## Commands
+
+### Running the Application
+- Main execution: `python ecstats.py -c config.ini`
+- With custom config: `python ecstats.py -c <config_file>`
+- With output directory: `python ecstats.py -c config.ini -d <output_dir>`
+- Docker execution: `docker run -v $(pwd):/app -t sumitshatwara/redis-ecstats python3 ecstats.py`
+
+### Environment Setup
+```bash
+python3 -m venv .env && source .env/bin/activate
+pip install -r requirements.txt
+cp config.ini.example config.ini
+# Edit config.ini with your AWS credentials and regions
+```
+
+### Testing
+```bash
+# Run all tests
+pytest test_ecstats.py -v
+
+# Run with coverage
+coverage run -m pytest test_ecstats.py
+coverage report -m
+```
+
+### Code Formatting
+```bash
+# Format code with black
+black ecstats.py test_ecstats.py
+
+# Check formatting without making changes
+black --check --diff ecstats.py test_ecstats.py
+```
+
+### Docker Build
+```bash
+docker build -t ecstats .
+```
+
+## Architecture
+
+### Core Components
+
+**Single File Application (`ecstats.py`):**
+- **Main execution flow**: `main()` → `process_aws_account()` → metric collection functions
+- **Configuration parsing**: Uses Python `configparser` to read multi-section config files
+- **AWS Integration**: Boto3 sessions with support for both credentials and IAM roles
+- **Metric collection**: Two metric categories with different collection periods:
+  - `get_max_metrics_weekly()`: 7-day metrics (configurable via `METRIC_COLLECTION_PERIOD_DAYS`)
+  - `get_max_metrics_hourly()`: Hourly command-based metrics
+- **Output generation**: Excel workbooks with two worksheets (ClusterData, ReservedData)
+
+### Key Functions
+- `get_clusters_info()`: Discovers ElastiCache instances and reserved instances
+- `get_metric()`/`get_metric_curr()`: CloudWatch metric retrieval
+- `get_running_instances_metrics()`: Collects and processes all metrics for active instances
+- `create_workbook()`: Generates Excel output structure
+
+### Configuration System
+- Multi-environment support via config sections (e.g., `[production]`, `[staging]`)
+- Supports both AWS credentials and IAM role-based authentication
+- Environment variable support for metric collection period: `METRIC_COLLECTION_PERIOD_DAYS`
+
+### Dependencies
+- `boto3`: AWS SDK for ElastiCache and CloudWatch APIs
+- `openpyxl`: Excel file generation
+- `pytest`: Testing framework with comprehensive test coverage
+- `black`: Code formatter for consistent Python style
+- Python 3.6+ required (tested on 3.8-3.12)
+
+### AWS Permissions Required
+- `CloudWatchReadOnlyAccess`
+- `AmazonElastiCacheReadOnlyAccess`
+
+### Output Format
+Excel files named `{section}-{region}.xlsx` containing:
+- **ClusterData sheet**: Instance details with ~45 performance metrics
+- **ReservedData sheet**: Reserved instance information
+- Metrics include Redis/Valkey command counts, latencies, memory usage, network stats

--- a/ecstats.py
+++ b/ecstats.py
@@ -473,29 +473,20 @@ def get_reserved_instances_info(wb, clusters_info):
 
 def process_aws_account(config, section, outDir):
     # Check if credentials are provided in the config file
-    if config.has_option(section, "aws_access_key_id") and config.has_option(
-        section, "aws_secret_access_key"
-    ):
-        aws_access_key_id = config.get(section, "aws_access_key_id")
-        aws_secret_access_key = config.get(section, "aws_secret_access_key")
-        region_name = config.get(section, "region_name")
+    region_name = config.get(section, "region_name")
 
-        if config.has_option(section, "aws_session_token"):
-            aws_session_token = config.get(section, "aws_session_token")
-        else:
-            aws_session_token = None
-
-        # Create session with credentials
-        session = boto3.Session(
-            aws_access_key_id=aws_access_key_id,
-            aws_secret_access_key=aws_secret_access_key,
-            aws_session_token=aws_session_token,
-            region_name=region_name,
-        )
+    if config.has_option(section, "profile_name"):
+        profile_name = config.get(section, "profile_name")
+        session = boto3.Session(profile_name=profile_name, region_name=region_name)
     else:
-        # No credentials in config file, rely on instance profile credentials
-        region_name = config.get(section, "region_name")
         session = boto3.Session(region_name=region_name)
+
+    sts = session.client("sts")
+    identity = sts.get_caller_identity()
+    print(f"Using AWS identity: {identity['Arn']}")
+
+    print(f"Requesting information for the {section} nodes")
+    clusters_info = get_clusters_info(session)
 
     print(f"Requesting information for the {section} nodes")
     clusters_info = get_clusters_info(session)
@@ -533,7 +524,7 @@ def main():
         metavar="PATH",
     )
 
-    (options, _) = parser.parse_args()
+    options, _ = parser.parse_args()
 
     if not os.path.isdir(options.outDir):
         os.makedirs(options.outDir)

--- a/ecstats.py
+++ b/ecstats.py
@@ -472,14 +472,25 @@ def get_reserved_instances_info(wb, clusters_info):
 
 
 def process_aws_account(config, section, outDir):
-    # Check if credentials are provided in the config file
     region_name = config.get(section, "region_name")
+    session_kwargs = {"region_name": region_name}
 
-    if config.has_option(section, "profile_name"):
-        profile_name = config.get(section, "profile_name")
-        session = boto3.Session(profile_name=profile_name, region_name=region_name)
-    else:
-        session = boto3.Session(region_name=region_name)
+    # Prefer explicit credentials from config.ini when present.
+    if config.has_option(section, "aws_access_key_id") and config.has_option(
+        section, "aws_secret_access_key"
+    ):
+        session_kwargs["aws_access_key_id"] = config.get(section, "aws_access_key_id")
+        session_kwargs["aws_secret_access_key"] = config.get(
+            section, "aws_secret_access_key"
+        )
+        if config.has_option(section, "aws_session_token"):
+            session_kwargs["aws_session_token"] = config.get(
+                section, "aws_session_token"
+            )
+    elif config.has_option(section, "profile_name"):
+        session_kwargs["profile_name"] = config.get(section, "profile_name")
+
+    session = boto3.Session(**session_kwargs)
 
     sts = session.client("sts")
     identity = sts.get_caller_identity()

--- a/test_ecstats.py
+++ b/test_ecstats.py
@@ -503,13 +503,25 @@ class TestIntegration:
 
                 mock_elasticache_client = Mock()
                 mock_cloudwatch_client = Mock()
-
+                mock_sts_client = Mock()
+                
+                mock_sts_client.get_caller_identity.return_value = {
+                    "UserId": "test-user",
+                    "Account": "123456789012",
+                    "Arn": "arn:aws:sts::123456789012:assumed-role/TestRole/test-session",
+                }
+                
                 def client_side_effect(service_name):
                     if service_name == "elasticache":
                         return mock_elasticache_client
                     elif service_name == "cloudwatch":
                         return mock_cloudwatch_client
+                    elif service_name == "sts":
+                        return mock_sts_client
                     return Mock()
+
+                
+
 
                 mock_session_instance.client.side_effect = client_side_effect
 

--- a/test_ecstats.py
+++ b/test_ecstats.py
@@ -477,6 +477,99 @@ class TestWorkbookOperations:
 class TestIntegration:
     """Integration tests."""
 
+    def test_process_aws_account_uses_direct_access_keys_from_config(self):
+        """Direct config credentials should be passed into boto3.Session."""
+        config = configparser.ConfigParser()
+        config.add_section("production")
+        config.set("production", "aws_access_key_id", "test-key")
+        config.set("production", "aws_secret_access_key", "test-secret")
+        config.set("production", "aws_session_token", "test-token")
+        config.set("production", "region_name", "us-west-1")
+
+        with tempfile.TemporaryDirectory() as temp_dir, patch(
+            "boto3.Session"
+        ) as mock_session, patch("ecstats.get_clusters_info") as mock_clusters, patch(
+            "ecstats.get_running_instances_metrics"
+        ) as mock_running, patch(
+            "ecstats.get_reserved_instances_info"
+        ) as mock_reserved, patch(
+            "ecstats.create_workbook"
+        ) as mock_workbook:
+            mock_session_instance = Mock()
+            mock_session.return_value = mock_session_instance
+
+            mock_sts_client = Mock()
+            mock_sts_client.get_caller_identity.return_value = {
+                "Arn": "arn:aws:sts::123456789012:assumed-role/TestRole/test-session"
+            }
+            mock_session_instance.client.return_value = mock_sts_client
+
+            mock_clusters.return_value = {
+                "elc_running_instances": {},
+                "elc_reserved_instances": {},
+                "snapshots": {},
+            }
+
+            workbook = Mock()
+            mock_workbook.return_value = workbook
+            mock_running.return_value = workbook
+            mock_reserved.return_value = workbook
+
+            ecstats.process_aws_account(config, "production", temp_dir)
+
+            mock_session.assert_called_once_with(
+                aws_access_key_id="test-key",
+                aws_secret_access_key="test-secret",
+                aws_session_token="test-token",
+                region_name="us-west-1",
+            )
+
+    def test_process_aws_account_prefers_access_keys_over_profile(self):
+        """Explicit config credentials should take precedence over profile_name."""
+        config = configparser.ConfigParser()
+        config.add_section("production")
+        config.set("production", "aws_access_key_id", "test-key")
+        config.set("production", "aws_secret_access_key", "test-secret")
+        config.set("production", "profile_name", "test-profile")
+        config.set("production", "region_name", "us-west-1")
+
+        with tempfile.TemporaryDirectory() as temp_dir, patch(
+            "boto3.Session"
+        ) as mock_session, patch("ecstats.get_clusters_info") as mock_clusters, patch(
+            "ecstats.get_running_instances_metrics"
+        ) as mock_running, patch(
+            "ecstats.get_reserved_instances_info"
+        ) as mock_reserved, patch(
+            "ecstats.create_workbook"
+        ) as mock_workbook:
+            mock_session_instance = Mock()
+            mock_session.return_value = mock_session_instance
+
+            mock_sts_client = Mock()
+            mock_sts_client.get_caller_identity.return_value = {
+                "Arn": "arn:aws:sts::123456789012:assumed-role/TestRole/test-session"
+            }
+            mock_session_instance.client.return_value = mock_sts_client
+
+            mock_clusters.return_value = {
+                "elc_running_instances": {},
+                "elc_reserved_instances": {},
+                "snapshots": {},
+            }
+
+            workbook = Mock()
+            mock_workbook.return_value = workbook
+            mock_running.return_value = workbook
+            mock_reserved.return_value = workbook
+
+            ecstats.process_aws_account(config, "production", temp_dir)
+
+            mock_session.assert_called_once_with(
+                aws_access_key_id="test-key",
+                aws_secret_access_key="test-secret",
+                region_name="us-west-1",
+            )
+
     def test_end_to_end_workflow_mock(self):
         """Test end-to-end workflow with comprehensive mocking."""
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/test_ecstats.py
+++ b/test_ecstats.py
@@ -504,13 +504,13 @@ class TestIntegration:
                 mock_elasticache_client = Mock()
                 mock_cloudwatch_client = Mock()
                 mock_sts_client = Mock()
-                
+
                 mock_sts_client.get_caller_identity.return_value = {
                     "UserId": "test-user",
                     "Account": "123456789012",
                     "Arn": "arn:aws:sts::123456789012:assumed-role/TestRole/test-session",
                 }
-                
+
                 def client_side_effect(service_name):
                     if service_name == "elasticache":
                         return mock_elasticache_client
@@ -519,9 +519,6 @@ class TestIntegration:
                     elif service_name == "sts":
                         return mock_sts_client
                     return Mock()
-
-                
-
 
                 mock_session_instance.client.side_effect = client_side_effect
 


### PR DESCRIPTION
Restored direct AWS credential authentication from config.ini in ecstats.py (line 474). process_aws_account() now passes aws_access_key_id and aws_secret_access_key into boto3.Session(...) when those settings are present, includes aws_session_token if provided, and otherwise falls back to profile_name or the default credential chain.

Added regression coverage in test_ecstats.py (line 480) for both cases:

verifies direct access keys from config are forwarded into boto3.Session
verifies direct access keys take precedence over profile_name when both are configured
Validation:

./.env/bin/python -m pytest test_ecstats.py -q passed with 15 passed
Existing datetime.utcnow() deprecation warnings remain unchanged and are unrelated to this fix