### PR TITLE
Add redis/valkey engine versions, Redis upgrade readiness and serverless reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Project Overview
+
+ECstats is a Python-based tool for extracting AWS ElastiCache (Redis/Valkey) database metrics via CloudWatch. It's a single-file application that generates Excel reports containing performance metrics and instance information.
+
+## Commands
+
+### Running the Application
+- Main execution: `python ecstats.py -c config.ini`
+- With custom config: `python ecstats.py -c <config_file>`
+- With output directory: `python ecstats.py -c config.ini -d <output_dir>`
+- Docker execution: `docker run -v $(pwd):/app -t sumitshatwara/redis-ecstats python3 ecstats.py`
+
+### Environment Setup
+```bash
+python3 -m venv .env && source .env/bin/activate
+pip install -r requirements.txt
+cp config.ini.example config.ini
+# Edit config.ini with your AWS credentials and regions
+```
+
+### Testing
+```bash
+# Run all tests
+pytest test_ecstats.py -v
+
+# Run with coverage
+coverage run -m pytest test_ecstats.py
+coverage report -m
+```
+
+### Code Formatting
+```bash
+# Format code with black
+black ecstats.py test_ecstats.py
+
+# Check formatting without making changes
+black --check --diff ecstats.py test_ecstats.py
+```
+
+### Docker Build
+```bash
+docker build -t ecstats .
+```
+
+## Architecture
+
+### Core Components
+
+**Single File Application (`ecstats.py`):**
+- **Main execution flow**: `main()` → `process_aws_account()` → metric collection functions
+- **Configuration parsing**: Uses Python `configparser` to read multi-section config files
+- **AWS Integration**: Boto3 sessions with support for both credentials and IAM roles
+- **Metric collection**: Two metric categories with different collection periods:
+  - `get_max_metrics_weekly()`: 7-day metrics (configurable via `METRIC_COLLECTION_PERIOD_DAYS`)
+  - `get_max_metrics_hourly()`: Hourly command-based metrics
+- **Output generation**: Excel workbooks with two worksheets (ClusterData, ReservedData)
+
+### Key Functions
+- `get_clusters_info()`: Discovers ElastiCache instances and reserved instances
+- `get_metric()`/`get_metric_curr()`: CloudWatch metric retrieval
+- `get_running_instances_metrics()`: Collects and processes all metrics for active instances
+- `create_workbook()`: Generates Excel output structure
+
+### Configuration System
+- Multi-environment support via config sections (e.g., `[production]`, `[staging]`)
+- Supports both AWS credentials and IAM role-based authentication
+- Environment variable support for metric collection period: `METRIC_COLLECTION_PERIOD_DAYS`
+
+### Dependencies
+- `boto3`: AWS SDK for ElastiCache and CloudWatch APIs
+- `openpyxl`: Excel file generation
+- `pytest`: Testing framework with comprehensive test coverage
+- `black`: Code formatter for consistent Python style
+- Python 3.6+ required (tested on 3.8-3.12)
+
+### AWS Permissions Required
+- `CloudWatchReadOnlyAccess`
+- `AmazonElastiCacheReadOnlyAccess`
+
+### Output Format
+Excel files named `{section}-{region}.xlsx` containing:
+- **ClusterData sheet**: Instance details with ~45 performance metrics
+- **ReservedData sheet**: Reserved instance information
+- Metrics include Redis/Valkey command counts, latencies, memory usage, network stats

--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ This script by no means will affect the performance and the data stored in the R
 
 The script will need at minimum CloudwatchReadOnlyAccess & AmazonElastiCacheReadOnlyAccess privilleges for extracting the information.
 
+## Redis upgrade readiness
+
+The generated workbook includes an `UpgradeReadiness` worksheet. This tab summarizes signals that can block or complicate a move to a newer Redis major version, including:
+
+- Engine versions below the target Redis major version.
+- Command-family traffic that may include Redis commands deprecated in Redis 8, such as `HMSET`, `SETEX`, `SETNX`, `GETSET`, legacy geospatial range commands, legacy sorted-set range commands, `BRPOPLPUSH`, and older cluster commands.
+- Auth/ACL failures, active traffic management, node/network allowance pressure, high CPU or memory pressure, evictions, swap usage, and missing automatic snapshot retention.
+
+ECstats still only reads ElastiCache and CloudWatch APIs. CloudWatch exposes aggregate command-family metrics, not exact command names, so deprecated-command findings are intentionally marked as potential usage that should be confirmed from application code, Redis commandstats, slow logs, or client telemetry.
+
+The default target is Redis major version `8`. You can tune the readiness thresholds with environment variables:
+
+```
+TARGET_REDIS_MAJOR_VERSION=8
+HIGH_CPU_THRESHOLD_PERCENT=90
+WARN_CPU_THRESHOLD_PERCENT=70
+HIGH_MEMORY_THRESHOLD_PERCENT=90
+WARN_MEMORY_THRESHOLD_PERCENT=75
+```
+
 
 ## Installation
 

--- a/ecstats.py
+++ b/ecstats.py
@@ -473,29 +473,20 @@ def get_reserved_instances_info(wb, clusters_info):
 
 def process_aws_account(config, section, outDir):
     # Check if credentials are provided in the config file
-    if config.has_option(section, "aws_access_key_id") and config.has_option(
-        section, "aws_secret_access_key"
-    ):
-        aws_access_key_id = config.get(section, "aws_access_key_id")
-        aws_secret_access_key = config.get(section, "aws_secret_access_key")
-        region_name = config.get(section, "region_name")
+    region_name = config.get(section, "region_name")
 
-        if config.has_option(section, "aws_session_token"):
-            aws_session_token = config.get(section, "aws_session_token")
-        else:
-            aws_session_token = None
-
-        # Create session with credentials
-        session = boto3.Session(
-            aws_access_key_id=aws_access_key_id,
-            aws_secret_access_key=aws_secret_access_key,
-            aws_session_token=aws_session_token,
-            region_name=region_name,
-        )
+    if config.has_option(section, "profile_name"):
+        profile_name = config.get(section, "profile_name")
+        session = boto3.Session(profile_name=profile_name, region_name=region_name)
     else:
-        # No credentials in config file, rely on instance profile credentials
-        region_name = config.get(section, "region_name")
         session = boto3.Session(region_name=region_name)
+
+    sts = session.client("sts")
+    identity = sts.get_caller_identity()
+    print(f"Using AWS identity: {identity['Arn']}")
+
+    print(f"Requesting information for the {section} nodes")
+    clusters_info = get_clusters_info(session)
 
     print(f"Requesting information for the {section} nodes")
     clusters_info = get_clusters_info(session)
@@ -533,7 +524,7 @@ def main():
         metavar="PATH",
     )
 
-    (options, _) = parser.parse_args()
+    options, _ = parser.parse_args()
 
     if not os.path.isdir(options.outDir):
         os.makedirs(options.outDir)

--- a/ecstats.py
+++ b/ecstats.py
@@ -472,14 +472,25 @@ def get_reserved_instances_info(wb, clusters_info):
 
 
 def process_aws_account(config, section, outDir):
-    # Check if credentials are provided in the config file
     region_name = config.get(section, "region_name")
+    session_kwargs = {"region_name": region_name}
 
-    if config.has_option(section, "profile_name"):
-        profile_name = config.get(section, "profile_name")
-        session = boto3.Session(profile_name=profile_name, region_name=region_name)
-    else:
-        session = boto3.Session(region_name=region_name)
+    # Prefer explicit credentials from config.ini when present.
+    if config.has_option(section, "aws_access_key_id") and config.has_option(
+        section, "aws_secret_access_key"
+    ):
+        session_kwargs["aws_access_key_id"] = config.get(section, "aws_access_key_id")
+        session_kwargs["aws_secret_access_key"] = config.get(
+            section, "aws_secret_access_key"
+        )
+        if config.has_option(section, "aws_session_token"):
+            session_kwargs["aws_session_token"] = config.get(
+                section, "aws_session_token"
+            )
+    elif config.has_option(section, "profile_name"):
+        session_kwargs["profile_name"] = config.get(section, "profile_name")
+
+    session = boto3.Session(**session_kwargs)
 
     sts = session.client("sts")
     identity = sts.get_caller_identity()

--- a/ecstats.py
+++ b/ecstats.py
@@ -372,6 +372,7 @@ def create_workbook(outDir, section, region_name):
     for metric, _, _ in get_max_metrics_hourly():
         df_columns.append(metric)
     df_columns.append("Engine")
+    df_columns.append("EngineVersion")
     df_columns.append("QPF")
     ws.append(df_columns)
 
@@ -451,6 +452,7 @@ def get_running_instances_metrics(wb, clusters_info, session):
                 # actual operation per second we then need to divide by 3600.
                 row.append(round(data_point / 60))
             row.append("%s" % instanceDetails["Engine"])
+            row.append("%s" % instanceDetails.get("EngineVersion", ""))
             row.append("")  # Empty qpf column
             ws.append(row)
             row = []

--- a/ecstats.py
+++ b/ecstats.py
@@ -17,6 +17,71 @@ SECONDS_IN_DAY = 24 * SECONDS_IN_HOUR
 
 RUNNING_INSTANCES_WORKSHEET_NAME = "ClusterData"
 RESERVED_INSTANCES_WORKSHEET_NAME = "ReservedData"
+UPGRADE_READINESS_WORKSHEET_NAME = "UpgradeReadiness"
+
+TARGET_REDIS_MAJOR_VERSION = int(os.environ.get("TARGET_REDIS_MAJOR_VERSION") or 8)
+
+HIGH_CPU_THRESHOLD_PERCENT = int(os.environ.get("HIGH_CPU_THRESHOLD_PERCENT") or 90)
+WARN_CPU_THRESHOLD_PERCENT = int(os.environ.get("WARN_CPU_THRESHOLD_PERCENT") or 70)
+HIGH_MEMORY_THRESHOLD_PERCENT = int(
+    os.environ.get("HIGH_MEMORY_THRESHOLD_PERCENT") or 90
+)
+WARN_MEMORY_THRESHOLD_PERCENT = int(
+    os.environ.get("WARN_MEMORY_THRESHOLD_PERCENT") or 75
+)
+
+DEPRECATED_COMMAND_GROUPS = {
+    "ClusterBasedCmds": [
+        "CLUSTER SLAVES -> CLUSTER REPLICAS",
+        "CLUSTER SLOTS -> CLUSTER SHARDS",
+    ],
+    "GeoSpatialBasedCmds": [
+        "GEORADIUS -> GEOSEARCH/GEOSEARCHSTORE BYRADIUS",
+        "GEORADIUS_RO -> GEOSEARCH BYRADIUS",
+        "GEORADIUSBYMEMBER -> GEOSEARCH/GEOSEARCHSTORE FROMMEMBER BYRADIUS",
+        "GEORADIUSBYMEMBER_RO -> GEOSEARCH FROMMEMBER BYRADIUS",
+    ],
+    "HashBasedCmds": ["HMSET -> HSET with multiple field-value pairs"],
+    "ListBasedCmds": ["BRPOPLPUSH -> BLMOVE RIGHT LEFT"],
+    "StringBasedCmds": [
+        "GETSET -> SET GET",
+        "SETEX -> SET EX",
+        "SETNX -> SET NX",
+        "SUBSTR -> GETRANGE",
+    ],
+    "SortedSetBasedCmds": [
+        "ZRANGEBYLEX -> ZRANGE BYLEX",
+        "ZRANGEBYSCORE -> ZRANGE BYSCORE",
+        "ZREVRANGE -> ZRANGE REV",
+        "ZREVRANGEBYLEX -> ZRANGE REV BYLEX",
+        "ZREVRANGEBYSCORE -> ZRANGE REV BYSCORE",
+    ],
+}
+
+AUTHORIZATION_FAILURE_METRICS = [
+    "AuthenticationFailures",
+    "ChannelAuthorizationFailures",
+    "CommandAuthorizationFailures",
+    "KeyAuthorizationFailures",
+]
+
+ALLOWANCE_EXCEEDED_METRICS = [
+    "NetworkBandwidthInAllowanceExceeded",
+    "NetworkBandwidthOutAllowanceExceeded",
+    "NetworkPacketsPerSecondAllowanceExceeded",
+]
+
+SERVERLESS_SUPPORTED_METRICS = {
+    "BytesUsedForCache",
+    "CacheHits",
+    "CacheHitRate",
+    "CacheMisses",
+    "ChannelAuthorizationFailures",
+    "CommandAuthorizationFailures",
+    "CurrItems",
+    "Evictions",
+    "KeyAuthorizationFailures",
+}
 
 
 def get_max_metrics_hourly():
@@ -203,6 +268,244 @@ def calc_expiry_time(expiry):
     return (expiry.replace(tzinfo=None) - datetime.datetime.utcnow()).days
 
 
+def parse_major_version(version):
+    if version is None:
+        return None
+
+    version_string = str(version).strip()
+    if not version_string:
+        return None
+
+    digits = []
+    for char in version_string:
+        if char.isdigit():
+            digits.append(char)
+        elif digits:
+            break
+        else:
+            return None
+
+    if not digits:
+        return None
+    return int("".join(digits))
+
+
+def get_region_from_arn(arn):
+    if not arn:
+        return ""
+    parts = arn.split(":")
+    if len(parts) > 3:
+        return parts[3]
+    return ""
+
+
+def append_upgrade_readiness_issue(
+    worksheet,
+    cluster_id,
+    node_id,
+    node_role,
+    instance_details,
+    severity,
+    category,
+    signal,
+    observed_value,
+    recommendation,
+    source="EC",
+):
+    worksheet.append(
+        [
+            source,
+            cluster_id,
+            node_id,
+            node_role,
+            instance_details["Engine"],
+            instance_details.get("EngineVersion", ""),
+            severity,
+            category,
+            signal,
+            observed_value,
+            recommendation,
+        ]
+    )
+
+
+def append_upgrade_readiness_issues(
+    worksheet,
+    cluster_id,
+    node_id,
+    node_role,
+    instance_details,
+    snapshot_retention_limit,
+    metric_values,
+    source="EC",
+):
+    engine = instance_details["Engine"]
+    engine_version = instance_details.get("EngineVersion", "")
+    major_version = parse_major_version(engine_version)
+    issue_count = 0
+
+    def add_issue(severity, category, signal, observed_value, recommendation):
+        nonlocal issue_count
+        append_upgrade_readiness_issue(
+            worksheet,
+            cluster_id,
+            node_id,
+            node_role,
+            instance_details,
+            severity,
+            category,
+            signal,
+            observed_value,
+            recommendation,
+            source=source,
+        )
+        issue_count += 1
+
+    if engine == "redis":
+        if major_version is None:
+            add_issue(
+                "High",
+                "EngineVersion",
+                "EngineVersion",
+                engine_version,
+                "Confirm the current engine version before planning a Redis major-version upgrade.",
+            )
+        elif major_version < TARGET_REDIS_MAJOR_VERSION:
+            add_issue(
+                "High",
+                "EngineVersion",
+                "EngineVersion",
+                engine_version,
+                "Plan and test an engine upgrade path to Redis major version %s or later."
+                % TARGET_REDIS_MAJOR_VERSION,
+            )
+    elif engine == "valkey":
+        add_issue(
+            "Info",
+            "EngineFamily",
+            "Engine",
+            engine,
+            "This node is Valkey; validate client and command compatibility against the Redis target separately.",
+        )
+
+    if snapshot_retention_limit <= 0:
+        add_issue(
+            "Medium",
+            "Recovery",
+            "SnapshotRetentionLimit",
+            snapshot_retention_limit,
+            "Enable automatic snapshots or confirm an alternate rollback plan before upgrading.",
+        )
+
+    for metric in AUTHORIZATION_FAILURE_METRICS:
+        value = metric_values.get(metric, 0)
+        if value > 0:
+            add_issue(
+                "High",
+                "Security",
+                metric,
+                value,
+                "Resolve ACL/auth failures before upgrading so client breakage is not confused with engine changes.",
+            )
+
+    for metric, deprecated_commands in DEPRECATED_COMMAND_GROUPS.items():
+        value = metric_values.get(metric, 0)
+        if value > 0:
+            add_issue(
+                "Medium",
+                "PotentialDeprecatedCommands",
+                metric,
+                value,
+                "CloudWatch saw traffic in a command family that includes deprecated Redis commands; review exact usage for: %s."
+                % "; ".join(deprecated_commands),
+            )
+
+    engine_cpu = metric_values.get("EngineCPUUtilization", 0)
+    if engine_cpu >= HIGH_CPU_THRESHOLD_PERCENT:
+        add_issue(
+            "High",
+            "Capacity",
+            "EngineCPUUtilization",
+            engine_cpu,
+            "Reduce CPU pressure or scale before upgrading; high CPU can make upgrade validation noisy.",
+        )
+    elif engine_cpu >= WARN_CPU_THRESHOLD_PERCENT:
+        add_issue(
+            "Medium",
+            "Capacity",
+            "EngineCPUUtilization",
+            engine_cpu,
+            "Review CPU headroom before upgrade testing.",
+        )
+
+    memory_usage = metric_values.get("DatabaseMemoryUsagePercentage", 0)
+    if memory_usage >= HIGH_MEMORY_THRESHOLD_PERCENT:
+        add_issue(
+            "High",
+            "Capacity",
+            "DatabaseMemoryUsagePercentage",
+            memory_usage,
+            "Lower memory pressure or scale before upgrading.",
+        )
+    elif memory_usage >= WARN_MEMORY_THRESHOLD_PERCENT:
+        add_issue(
+            "Medium",
+            "Capacity",
+            "DatabaseMemoryUsagePercentage",
+            memory_usage,
+            "Review memory headroom before upgrade testing.",
+        )
+
+    for metric in ALLOWANCE_EXCEEDED_METRICS:
+        value = metric_values.get(metric, 0)
+        if value > 0:
+            add_issue(
+                "Medium",
+                "Capacity",
+                metric,
+                value,
+                "Investigate node/network limits before upgrading.",
+            )
+
+    if metric_values.get("TrafficManagementActive", 0) > 0:
+        add_issue(
+            "High",
+            "Capacity",
+            "TrafficManagementActive",
+            metric_values.get("TrafficManagementActive", 0),
+            "Resolve active traffic management before upgrading.",
+        )
+
+    if metric_values.get("Evictions", 0) > 0:
+        add_issue(
+            "Medium",
+            "DataRisk",
+            "Evictions",
+            metric_values.get("Evictions", 0),
+            "Review eviction pressure and maxmemory policy before upgrading.",
+        )
+
+    if metric_values.get("SwapUsage", 0) > 0:
+        add_issue(
+            "Medium",
+            "Capacity",
+            "SwapUsage",
+            metric_values.get("SwapUsage", 0),
+            "Reduce swap usage before upgrading.",
+        )
+
+    if issue_count == 0:
+        add_issue(
+            "Info",
+            "UpgradeReadiness",
+            "NoRoadblocksDetected",
+            "",
+            "No upgrade roadblocks were detected from the collected ElastiCache and CloudWatch signals.",
+        )
+
+    return worksheet
+
+
 def get_clusters_info(session):
     """Calculate the running/reserved instances in ElastiCache.
     Args:
@@ -214,6 +517,7 @@ def get_clusters_info(session):
     results = {
         "elc_running_instances": {},
         "elc_reserved_instances": {},
+        "elc_serverless_caches": {},
     }
 
     paginator = conn.get_paginator("describe_cache_clusters")
@@ -251,6 +555,29 @@ def get_clusters_info(session):
             ):
                 cluster_id = instance["CacheClusterId"]
                 results["elc_running_instances"][cluster_id] = instance
+
+    next_token = None
+    while True:
+        try:
+            request = {"NextToken": next_token} if next_token else {}
+            serverless_caches = conn.describe_serverless_caches(**request)
+        except:
+            break
+
+        if not isinstance(serverless_caches, dict):
+            break
+
+        for serverless_cache in serverless_caches.get("ServerlessCaches", []):
+            if serverless_cache["Status"] == "available" and (
+                serverless_cache["Engine"] == "redis"
+                or serverless_cache["Engine"] == "valkey"
+            ):
+                cache_name = serverless_cache["ServerlessCacheName"]
+                results["elc_serverless_caches"][cache_name] = serverless_cache
+
+        next_token = serverless_caches.get("NextToken")
+        if not next_token:
+            break
 
     paginator = conn.get_paginator("describe_reserved_cache_nodes")
     page_iterator = paginator.paginate()
@@ -294,6 +621,25 @@ def get_metric(cloud_watch, cluster_id, node, metric, aggregation, period):
         Dimensions=[
             {"Name": "CacheClusterId", "Value": cluster_id},
             {"Name": "CacheNodeId", "Value": node},
+        ],
+        StartTime=then.isoformat(),
+        EndTime=today.isoformat(),
+        Period=period,
+        Statistics=[aggregation],
+    )
+
+    raw_data = [rec[aggregation] for rec in response["Datapoints"]]
+    return raw_data
+
+
+def get_serverless_metric(cloud_watch, cluster_id, metric, aggregation, period):
+    today = datetime.date.today() + datetime.timedelta(days=1)
+    then = today - datetime.timedelta(days=METRIC_COLLECTION_PERIOD_DAYS)
+    response = cloud_watch.get_metric_statistics(
+        Namespace="AWS/ElastiCache",
+        MetricName=metric,
+        Dimensions=[
+            {"Name": "clusterId", "Value": cluster_id},
         ],
         StartTime=then.isoformat(),
         EndTime=today.isoformat(),
@@ -379,6 +725,22 @@ def create_workbook(outDir, section, region_name):
     ws = wb.create_sheet(RESERVED_INSTANCES_WORKSHEET_NAME)
     df_columns = ["Instance Type", "Count", "Remaining Time (days)"]
     ws.append(df_columns)
+
+    ws = wb.create_sheet(UPGRADE_READINESS_WORKSHEET_NAME)
+    df_columns = [
+        "Source",
+        "ClusterId",
+        "NodeId",
+        "NodeRole",
+        "Engine",
+        "EngineVersion",
+        "Severity",
+        "Category",
+        "Signal",
+        "ObservedValue",
+        "Recommendation",
+    ]
+    ws.append(df_columns)
     return wb
 
 
@@ -391,7 +753,9 @@ def get_running_instances_metrics(wb, clusters_info, session):
     """
     cloud_watch = session.client("cloudwatch")
     running_instances = clusters_info["elc_running_instances"]
+    serverless_caches = clusters_info.get("elc_serverless_caches", {})
     ws = wb[RUNNING_INSTANCES_WORKSHEET_NAME]
+    upgrade_ws = wb[UPGRADE_READINESS_WORKSHEET_NAME]
     row = []
 
     for instanceId, instanceDetails in running_instances.items():
@@ -425,6 +789,7 @@ def get_running_instances_metrics(wb, clusters_info, session):
             row.append("%s" % instanceDetails["PreferredAvailabilityZone"])
             row.append("%s" % snapshotRetentionLimit)
 
+            metric_values = {}
             for metric, aggregation, period in get_max_metrics_weekly():
                 data_points = get_metric(
                     cloud_watch,
@@ -435,6 +800,7 @@ def get_running_instances_metrics(wb, clusters_info, session):
                     period,
                 )
                 data_point = 0 if len(data_points) == 0 else data_points[0]
+                metric_values[metric] = data_point
                 row.append(data_point)
             for metric, aggregation, period in get_max_metrics_hourly():
                 data_points = get_metric(
@@ -450,12 +816,82 @@ def get_running_instances_metrics(wb, clusters_info, session):
                 # in order to get the real hourly stats. Cloudwatch is sampling at minimum once every minute
                 # so we need to multiply by 60 in order to simulate an hourly throughput. In order to get
                 # actual operation per second we then need to divide by 3600.
-                row.append(round(data_point / 60))
+                hourly_value = round(data_point / 60)
+                metric_values[metric] = hourly_value
+                row.append(hourly_value)
             row.append("%s" % instanceDetails["Engine"])
             row.append("%s" % instanceDetails.get("EngineVersion", ""))
             row.append("")  # Empty qpf column
             ws.append(row)
+            append_upgrade_readiness_issues(
+                upgrade_ws,
+                clusterId,
+                instanceId,
+                nodeRole,
+                instanceDetails,
+                snapshotRetentionLimit,
+                metric_values,
+            )
             row = []
+
+    for cacheId, cacheDetails in serverless_caches.items():
+        print("Fetching serverless cache %s details" % cacheId)
+        snapshotRetentionLimit = cacheDetails.get("SnapshotRetentionLimit", -1)
+        region = get_region_from_arn(cacheDetails.get("ARN", ""))
+
+        row.append("EC-Serverless")
+        row.append("%s" % cacheId)
+        row.append("")
+        row.append("Serverless")
+        row.append("serverless")
+        row.append("%s" % region)
+        row.append("%s" % snapshotRetentionLimit)
+
+        metric_values = {}
+        for metric, aggregation, period in get_max_metrics_weekly():
+            if metric not in SERVERLESS_SUPPORTED_METRICS:
+                row.append("")
+                continue
+
+            data_points = get_serverless_metric(
+                cloud_watch,
+                cacheId,
+                metric,
+                aggregation,
+                period,
+            )
+            data_point = 0 if len(data_points) == 0 else data_points[0]
+            metric_values[metric] = data_point
+            row.append(data_point)
+
+        for metric, _, _ in get_max_metrics_hourly():
+            row.append("")
+
+        row.append("%s" % cacheDetails["Engine"])
+        row.append(
+            "%s"
+            % cacheDetails.get(
+                "FullEngineVersion", cacheDetails.get("MajorEngineVersion", "")
+            )
+        )
+        row.append("")
+        ws.append(row)
+        append_upgrade_readiness_issues(
+            upgrade_ws,
+            cacheId,
+            "",
+            "Serverless",
+            {
+                "Engine": cacheDetails["Engine"],
+                "EngineVersion": cacheDetails.get(
+                    "FullEngineVersion", cacheDetails.get("MajorEngineVersion", "")
+                ),
+            },
+            snapshotRetentionLimit,
+            metric_values,
+            source="EC-Serverless",
+        )
+        row = []
     return wb
 
 

--- a/test_ecstats.py
+++ b/test_ecstats.py
@@ -503,13 +503,25 @@ class TestIntegration:
 
                 mock_elasticache_client = Mock()
                 mock_cloudwatch_client = Mock()
-
+                mock_sts_client = Mock()
+                
+                mock_sts_client.get_caller_identity.return_value = {
+                    "UserId": "test-user",
+                    "Account": "123456789012",
+                    "Arn": "arn:aws:sts::123456789012:assumed-role/TestRole/test-session",
+                }
+                
                 def client_side_effect(service_name):
                     if service_name == "elasticache":
                         return mock_elasticache_client
                     elif service_name == "cloudwatch":
                         return mock_cloudwatch_client
+                    elif service_name == "sts":
+                        return mock_sts_client
                     return Mock()
+
+                
+
 
                 mock_session_instance.client.side_effect = client_side_effect
 

--- a/test_ecstats.py
+++ b/test_ecstats.py
@@ -477,6 +477,99 @@ class TestWorkbookOperations:
 class TestIntegration:
     """Integration tests."""
 
+    def test_process_aws_account_uses_direct_access_keys_from_config(self):
+        """Direct config credentials should be passed into boto3.Session."""
+        config = configparser.ConfigParser()
+        config.add_section("production")
+        config.set("production", "aws_access_key_id", "test-key")
+        config.set("production", "aws_secret_access_key", "test-secret")
+        config.set("production", "aws_session_token", "test-token")
+        config.set("production", "region_name", "us-west-1")
+
+        with tempfile.TemporaryDirectory() as temp_dir, patch(
+            "boto3.Session"
+        ) as mock_session, patch("ecstats.get_clusters_info") as mock_clusters, patch(
+            "ecstats.get_running_instances_metrics"
+        ) as mock_running, patch(
+            "ecstats.get_reserved_instances_info"
+        ) as mock_reserved, patch(
+            "ecstats.create_workbook"
+        ) as mock_workbook:
+            mock_session_instance = Mock()
+            mock_session.return_value = mock_session_instance
+
+            mock_sts_client = Mock()
+            mock_sts_client.get_caller_identity.return_value = {
+                "Arn": "arn:aws:sts::123456789012:assumed-role/TestRole/test-session"
+            }
+            mock_session_instance.client.return_value = mock_sts_client
+
+            mock_clusters.return_value = {
+                "elc_running_instances": {},
+                "elc_reserved_instances": {},
+                "snapshots": {},
+            }
+
+            workbook = Mock()
+            mock_workbook.return_value = workbook
+            mock_running.return_value = workbook
+            mock_reserved.return_value = workbook
+
+            ecstats.process_aws_account(config, "production", temp_dir)
+
+            mock_session.assert_called_once_with(
+                aws_access_key_id="test-key",
+                aws_secret_access_key="test-secret",
+                aws_session_token="test-token",
+                region_name="us-west-1",
+            )
+
+    def test_process_aws_account_prefers_access_keys_over_profile(self):
+        """Explicit config credentials should take precedence over profile_name."""
+        config = configparser.ConfigParser()
+        config.add_section("production")
+        config.set("production", "aws_access_key_id", "test-key")
+        config.set("production", "aws_secret_access_key", "test-secret")
+        config.set("production", "profile_name", "test-profile")
+        config.set("production", "region_name", "us-west-1")
+
+        with tempfile.TemporaryDirectory() as temp_dir, patch(
+            "boto3.Session"
+        ) as mock_session, patch("ecstats.get_clusters_info") as mock_clusters, patch(
+            "ecstats.get_running_instances_metrics"
+        ) as mock_running, patch(
+            "ecstats.get_reserved_instances_info"
+        ) as mock_reserved, patch(
+            "ecstats.create_workbook"
+        ) as mock_workbook:
+            mock_session_instance = Mock()
+            mock_session.return_value = mock_session_instance
+
+            mock_sts_client = Mock()
+            mock_sts_client.get_caller_identity.return_value = {
+                "Arn": "arn:aws:sts::123456789012:assumed-role/TestRole/test-session"
+            }
+            mock_session_instance.client.return_value = mock_sts_client
+
+            mock_clusters.return_value = {
+                "elc_running_instances": {},
+                "elc_reserved_instances": {},
+                "snapshots": {},
+            }
+
+            workbook = Mock()
+            mock_workbook.return_value = workbook
+            mock_running.return_value = workbook
+            mock_reserved.return_value = workbook
+
+            ecstats.process_aws_account(config, "production", temp_dir)
+
+            mock_session.assert_called_once_with(
+                aws_access_key_id="test-key",
+                aws_secret_access_key="test-secret",
+                region_name="us-west-1",
+            )
+
     def test_end_to_end_workflow_mock(self):
         """Test end-to-end workflow with comprehensive mocking."""
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/test_ecstats.py
+++ b/test_ecstats.py
@@ -504,13 +504,13 @@ class TestIntegration:
                 mock_elasticache_client = Mock()
                 mock_cloudwatch_client = Mock()
                 mock_sts_client = Mock()
-                
+
                 mock_sts_client.get_caller_identity.return_value = {
                     "UserId": "test-user",
                     "Account": "123456789012",
                     "Arn": "arn:aws:sts::123456789012:assumed-role/TestRole/test-session",
                 }
-                
+
                 def client_side_effect(service_name):
                     if service_name == "elasticache":
                         return mock_elasticache_client
@@ -519,9 +519,6 @@ class TestIntegration:
                     elif service_name == "sts":
                         return mock_sts_client
                     return Mock()
-
-                
-
 
                 mock_session_instance.client.side_effect = client_side_effect
 

--- a/test_ecstats.py
+++ b/test_ecstats.py
@@ -107,6 +107,7 @@ class TestClusterInfo:
                 "CacheClusterId": "test-cluster-001",
                 "CacheClusterStatus": "available",
                 "Engine": "redis",
+                "EngineVersion": "7.1",
                 "CacheNodeType": "cache.t3.micro",
                 "CacheNodes": [{"CacheNodeId": "0001"}],
             }
@@ -126,6 +127,10 @@ class TestClusterInfo:
         assert isinstance(result["elc_running_instances"], dict)
         assert isinstance(result["elc_reserved_instances"], dict)
         assert isinstance(result["snapshots"], dict)
+        assert (
+            result["elc_running_instances"]["test-cluster-001"]["EngineVersion"]
+            == "7.1"
+        )
 
     @patch("boto3.Session")
     def test_get_clusters_info_redis_engine_only(self, mock_session):
@@ -141,6 +146,7 @@ class TestClusterInfo:
                 "CacheClusterId": "redis-cluster-001",
                 "CacheClusterStatus": "available",
                 "Engine": "redis",
+                "EngineVersion": "7.0",
                 "CacheNodeType": "cache.r6g.large",
                 "CacheNodes": [
                     {"CacheNodeId": "0001"},
@@ -151,6 +157,7 @@ class TestClusterInfo:
                 "CacheClusterId": "redis-cluster-002",
                 "CacheClusterStatus": "available",
                 "Engine": "redis",
+                "EngineVersion": "6.2",
                 "CacheNodeType": "cache.t3.medium",
                 "CacheNodes": [{"CacheNodeId": "0001"}],
             },
@@ -184,6 +191,7 @@ class TestClusterInfo:
                 "CacheClusterId": "valkey-cluster-001",
                 "CacheClusterStatus": "available",
                 "Engine": "valkey",
+                "EngineVersion": "8.0",
                 "CacheNodeType": "cache.r7g.xlarge",
                 "CacheNodes": [{"CacheNodeId": "0001"}],
             },
@@ -191,6 +199,7 @@ class TestClusterInfo:
                 "CacheClusterId": "valkey-cluster-002",
                 "CacheClusterStatus": "available",
                 "Engine": "valkey",
+                "EngineVersion": "7.2",
                 "CacheNodeType": "cache.m6g.large",
                 "CacheNodes": [
                     {"CacheNodeId": "0001"},
@@ -213,6 +222,7 @@ class TestClusterInfo:
         # Verify Valkey engine is preserved
         for cluster_info in result["elc_running_instances"].values():
             assert cluster_info["Engine"] == "valkey"
+            assert cluster_info["EngineVersion"] in ["8.0", "7.2"]
 
     @patch("boto3.Session")
     def test_get_clusters_info_filters_redis_valkey_only(self, mock_session):
@@ -471,7 +481,43 @@ class TestWorkbookOperations:
 
             # Should have metrics from both weekly and hourly
             assert "Engine" in headers
+            assert "EngineVersion" in headers
             assert "QPF" in headers
+
+    def test_get_running_instances_metrics_includes_engine_version(self):
+        """Test running instance rows include engine family and version."""
+        wb = ecstats.create_workbook(".", "test-section", "us-west-1")
+        clusters_info = {
+            "elc_running_instances": {
+                "test-cluster-001": {
+                    "CacheClusterId": "test-cluster-001",
+                    "CacheClusterStatus": "available",
+                    "Engine": "valkey",
+                    "EngineVersion": "8.0",
+                    "CacheNodeType": "cache.t3.micro",
+                    "PreferredAvailabilityZone": "us-west-1a",
+                    "CacheNodes": [{"CacheNodeId": "0001"}],
+                }
+            },
+            "elc_reserved_instances": {},
+            "snapshots": {},
+        }
+        mock_session = Mock()
+        mock_cloudwatch = Mock()
+        mock_session.client.return_value = mock_cloudwatch
+
+        with patch("ecstats.get_metric_curr", return_value=1.0), patch(
+            "ecstats.get_metric", return_value=[60.0]
+        ):
+            wb = ecstats.get_running_instances_metrics(wb, clusters_info, mock_session)
+
+        ws = wb[ecstats.RUNNING_INSTANCES_WORKSHEET_NAME]
+        headers = [cell.value for cell in ws[1]]
+        row = [cell.value for cell in ws[2]]
+
+        assert row[headers.index("Engine")] == "valkey"
+        assert row[headers.index("EngineVersion")] == "8.0"
+        assert row[headers.index("QPF")] == ""
 
 
 class TestIntegration:
@@ -621,6 +667,7 @@ class TestIntegration:
                         "CacheClusterId": "test-cluster-001",
                         "CacheClusterStatus": "available",
                         "Engine": "redis",
+                        "EngineVersion": "7.1",
                         "CacheNodeType": "cache.t3.micro",
                         "PreferredAvailabilityZone": "us-west-1a",
                         "CacheNodes": [{"CacheNodeId": "0001"}],
@@ -653,6 +700,11 @@ class TestIntegration:
                 wb = openpyxl.load_workbook(expected_output)
                 assert ecstats.RUNNING_INSTANCES_WORKSHEET_NAME in wb.sheetnames
                 assert ecstats.RESERVED_INSTANCES_WORKSHEET_NAME in wb.sheetnames
+                ws = wb[ecstats.RUNNING_INSTANCES_WORKSHEET_NAME]
+                headers = [cell.value for cell in ws[1]]
+                row = [cell.value for cell in ws[2]]
+                assert row[headers.index("Engine")] == "redis"
+                assert row[headers.index("EngineVersion")] == "7.1"
 
 
 if __name__ == "__main__":

--- a/test_ecstats.py
+++ b/test_ecstats.py
@@ -87,6 +87,14 @@ class TestUtilityFunctions:
         days_until_expiry = ecstats.calc_expiry_time(past_date)
         assert days_until_expiry < 0
 
+    def test_parse_major_version(self):
+        """Test Redis/Valkey major version parsing."""
+        assert ecstats.parse_major_version("7.1") == 7
+        assert ecstats.parse_major_version("8.0.1") == 8
+        assert ecstats.parse_major_version("") is None
+        assert ecstats.parse_major_version(None) is None
+        assert ecstats.parse_major_version("unknown") is None
+
 
 class TestClusterInfo:
     """Test cluster information retrieval."""
@@ -123,9 +131,11 @@ class TestClusterInfo:
 
         assert "elc_running_instances" in result
         assert "elc_reserved_instances" in result
+        assert "elc_serverless_caches" in result
         assert "snapshots" in result
         assert isinstance(result["elc_running_instances"], dict)
         assert isinstance(result["elc_reserved_instances"], dict)
+        assert isinstance(result["elc_serverless_caches"], dict)
         assert isinstance(result["snapshots"], dict)
         assert (
             result["elc_running_instances"]["test-cluster-001"]["EngineVersion"]
@@ -394,6 +404,41 @@ class TestClusterInfo:
         assert isinstance(redis_ri["expiry_time"], int)
         assert isinstance(valkey_ri["expiry_time"], int)
 
+    @patch("boto3.Session")
+    def test_get_clusters_info_with_serverless_cache(self, mock_session):
+        """Test processing of available serverless Redis caches."""
+        mock_session_instance = Mock()
+        mock_session.return_value = mock_session_instance
+
+        mock_elasticache_client = Mock()
+        mock_session_instance.client.return_value = mock_elasticache_client
+        mock_elasticache_client.get_paginator.side_effect = (
+            create_paginator_side_effect()
+        )
+        mock_elasticache_client.describe_snapshots.return_value = {"Snapshots": []}
+        mock_elasticache_client.describe_serverless_caches.return_value = {
+            "ServerlessCaches": [
+                {
+                    "ServerlessCacheName": "serverless-redis",
+                    "Status": "available",
+                    "Engine": "redis",
+                    "FullEngineVersion": "7.1",
+                    "SnapshotRetentionLimit": 0,
+                },
+                {
+                    "ServerlessCacheName": "serverless-creating",
+                    "Status": "creating",
+                    "Engine": "redis",
+                },
+            ]
+        }
+
+        result = ecstats.get_clusters_info(mock_session_instance)
+
+        assert len(result["elc_serverless_caches"]) == 1
+        assert "serverless-redis" in result["elc_serverless_caches"]
+        assert "serverless-creating" not in result["elc_serverless_caches"]
+
 
 class TestMetricRetrieval:
     """Test metric retrieval functions."""
@@ -448,6 +493,27 @@ class TestMetricRetrieval:
 
         assert result == -1
 
+    @patch("datetime.date")
+    def test_get_serverless_metric(self, mock_date):
+        """Test serverless CloudWatch metric retrieval uses clusterId dimension."""
+        mock_today = datetime.date(2023, 1, 8)
+        mock_date.today.return_value = mock_today
+
+        mock_cloudwatch = Mock()
+        mock_cloudwatch.get_metric_statistics.return_value = {
+            "Datapoints": [{"Maximum": 42.0}]
+        }
+
+        result = ecstats.get_serverless_metric(
+            mock_cloudwatch, "serverless-redis", "CurrItems", "Maximum", 3600
+        )
+
+        assert result == [42.0]
+        call_args = mock_cloudwatch.get_metric_statistics.call_args
+        assert call_args[1]["Dimensions"] == [
+            {"Name": "clusterId", "Value": "serverless-redis"}
+        ]
+
 
 class TestWorkbookOperations:
     """Test Excel workbook operations."""
@@ -458,9 +524,10 @@ class TestWorkbookOperations:
             wb = ecstats.create_workbook(temp_dir, "test-section", "us-west-1")
 
             assert isinstance(wb, openpyxl.Workbook)
-            assert len(wb.sheetnames) == 2
+            assert len(wb.sheetnames) == 3
             assert ecstats.RUNNING_INSTANCES_WORKSHEET_NAME in wb.sheetnames
             assert ecstats.RESERVED_INSTANCES_WORKSHEET_NAME in wb.sheetnames
+            assert ecstats.UPGRADE_READINESS_WORKSHEET_NAME in wb.sheetnames
 
             # Check running instances worksheet headers
             ws = wb[ecstats.RUNNING_INSTANCES_WORKSHEET_NAME]
@@ -483,6 +550,22 @@ class TestWorkbookOperations:
             assert "Engine" in headers
             assert "EngineVersion" in headers
             assert "QPF" in headers
+
+            upgrade_ws = wb[ecstats.UPGRADE_READINESS_WORKSHEET_NAME]
+            upgrade_headers = [cell.value for cell in upgrade_ws[1]]
+            assert upgrade_headers == [
+                "Source",
+                "ClusterId",
+                "NodeId",
+                "NodeRole",
+                "Engine",
+                "EngineVersion",
+                "Severity",
+                "Category",
+                "Signal",
+                "ObservedValue",
+                "Recommendation",
+            ]
 
     def test_get_running_instances_metrics_includes_engine_version(self):
         """Test running instance rows include engine family and version."""
@@ -518,6 +601,126 @@ class TestWorkbookOperations:
         assert row[headers.index("Engine")] == "valkey"
         assert row[headers.index("EngineVersion")] == "8.0"
         assert row[headers.index("QPF")] == ""
+
+    def test_get_running_instances_metrics_adds_upgrade_findings(self):
+        """Test readiness sheet flags Redis upgrade roadblocks and deprecated command families."""
+        wb = ecstats.create_workbook(".", "test-section", "us-west-1")
+        clusters_info = {
+            "elc_running_instances": {
+                "test-cluster-001": {
+                    "CacheClusterId": "test-cluster-001",
+                    "CacheClusterStatus": "available",
+                    "Engine": "redis",
+                    "EngineVersion": "6.2",
+                    "CacheNodeType": "cache.t3.micro",
+                    "PreferredAvailabilityZone": "us-west-1a",
+                    "CacheNodes": [{"CacheNodeId": "0001"}],
+                }
+            },
+            "elc_reserved_instances": {},
+            "snapshots": {"test-cluster-001": 7},
+        }
+        mock_session = Mock()
+        mock_cloudwatch = Mock()
+        mock_session.client.return_value = mock_cloudwatch
+
+        def metric_side_effect(_cloud_watch, _cluster_id, _node, metric, *_args):
+            if metric == "StringBasedCmds":
+                return [600.0]
+            if metric == "AuthenticationFailures":
+                return [1.0]
+            if metric == "EngineCPUUtilization":
+                return [95.0]
+            return [0.0]
+
+        with patch("ecstats.get_metric_curr", return_value=1.0), patch(
+            "ecstats.get_metric", side_effect=metric_side_effect
+        ):
+            wb = ecstats.get_running_instances_metrics(wb, clusters_info, mock_session)
+
+        ws = wb[ecstats.UPGRADE_READINESS_WORKSHEET_NAME]
+        headers = [cell.value for cell in ws[1]]
+        rows = [[cell.value for cell in row] for row in ws.iter_rows(min_row=2)]
+
+        signals = [row[headers.index("Signal")] for row in rows]
+        categories = [row[headers.index("Category")] for row in rows]
+
+        assert "EngineVersion" in signals
+        assert "AuthenticationFailures" in signals
+        assert "StringBasedCmds" in signals
+        assert "EngineCPUUtilization" in signals
+        assert "PotentialDeprecatedCommands" in categories
+
+        deprecated_row = rows[signals.index("StringBasedCmds")]
+        recommendation = deprecated_row[headers.index("Recommendation")]
+        assert "SETEX -> SET EX" in recommendation
+
+    def test_append_upgrade_readiness_issues_records_no_findings(self):
+        """Test clean nodes get an explicit no-roadblocks row."""
+        wb = ecstats.create_workbook(".", "test-section", "us-west-1")
+        ws = wb[ecstats.UPGRADE_READINESS_WORKSHEET_NAME]
+        instance_details = {
+            "Engine": "redis",
+            "EngineVersion": "%s.0" % ecstats.TARGET_REDIS_MAJOR_VERSION,
+        }
+
+        ecstats.append_upgrade_readiness_issues(
+            ws,
+            "test-cluster",
+            "test-node",
+            "Master",
+            instance_details,
+            7,
+            {},
+        )
+
+        headers = [cell.value for cell in ws[1]]
+        row = [cell.value for cell in ws[2]]
+
+        assert row[headers.index("Severity")] == "Info"
+        assert row[headers.index("Signal")] == "NoRoadblocksDetected"
+
+    def test_get_running_instances_metrics_includes_serverless_cache(self):
+        """Test serverless cache rows are included in workbook output."""
+        wb = ecstats.create_workbook(".", "test-section", "us-west-2")
+        clusters_info = {
+            "elc_running_instances": {},
+            "elc_reserved_instances": {},
+            "elc_serverless_caches": {
+                "serverless-redis": {
+                    "ServerlessCacheName": "serverless-redis",
+                    "Status": "available",
+                    "Engine": "redis",
+                    "FullEngineVersion": "7.1",
+                    "SnapshotRetentionLimit": 0,
+                    "ARN": "arn:aws:elasticache:us-west-2:123456789012:serverlesscache:serverless-redis",
+                }
+            },
+            "snapshots": {},
+        }
+        mock_session = Mock()
+        mock_cloudwatch = Mock()
+        mock_session.client.return_value = mock_cloudwatch
+
+        with patch("ecstats.get_serverless_metric", return_value=[12.0]):
+            wb = ecstats.get_running_instances_metrics(wb, clusters_info, mock_session)
+
+        ws = wb[ecstats.RUNNING_INSTANCES_WORKSHEET_NAME]
+        headers = [cell.value for cell in ws[1]]
+        row = [cell.value for cell in ws[2]]
+
+        assert row[headers.index("Source")] == "EC-Serverless"
+        assert row[headers.index("ClusterId")] == "serverless-redis"
+        assert row[headers.index("NodeRole")] == "Serverless"
+        assert row[headers.index("NodeType")] == "serverless"
+        assert row[headers.index("Region")] == "us-west-2"
+        assert row[headers.index("CurrItems")] == 12.0
+        assert row[headers.index("EngineVersion")] == "7.1"
+
+        upgrade_ws = wb[ecstats.UPGRADE_READINESS_WORKSHEET_NAME]
+        upgrade_headers = [cell.value for cell in upgrade_ws[1]]
+        upgrade_row = [cell.value for cell in upgrade_ws[2]]
+        assert upgrade_row[upgrade_headers.index("Source")] == "EC-Serverless"
 
 
 class TestIntegration:


### PR DESCRIPTION
## Summary
- add an UpgradeReadiness worksheet that flags Redis major-version gaps, possible deprecated command-family usage, auth/ACL failures, snapshot/rollback gaps, and capacity risks
- include ElastiCache Serverless Redis/Valkey caches in discovery and workbook output using serverless CloudWatch dimensions
- document the new upgrade-readiness worksheet and tunable thresholds

## Validation
- .env/bin/python -m pytest test_ecstats.py -v
- .env/bin/python -m black --check --diff ecstats.py test_ecstats.py
- generated production-us-west-2.xlsx locally and verified it includes both the provisioned cache and serverless cache rows