### PR TITLE
Fix black formatting failure on main

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install black
       run: |
         python -m pip install --upgrade pip
-        pip install black>=25.1.0
+        pip install black==26.5.1
 
     - name: Check code formatting with black
       run: |

--- a/ecstats.py
+++ b/ecstats.py
@@ -533,7 +533,7 @@ def main():
         metavar="PATH",
     )
 
-    (options, _) = parser.parse_args()
+    options, _ = parser.parse_args()
 
     if not os.path.isdir(options.outDir):
         os.makedirs(options.outDir)


### PR DESCRIPTION
CI formatting check on `main` fails because latest black flags redundant parentheses in a tuple assignment:

```diff
-    (options, _) = parser.parse_args()
+    options, _ = parser.parse_args()
```

Why it passes locally with black 25.1.0 but fails in CI: the workflow step `pip install black>=25.1.0` is unquoted, so the shell treats `>=25.1.0` as an output redirect and pip installs the **latest** black (currently 26.5.1), which added this style change. Verified both files pass `black --check` under 26.5.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)